### PR TITLE
Removed useless include of Platform.h

### DIFF
--- a/libraries/EasyVR/EasyVRBridge.cpp
+++ b/libraries/EasyVR/EasyVRBridge.cpp
@@ -11,7 +11,6 @@ file COPYING.txt or at this address: <http://www.opensource.org/licenses/MIT>
 
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"
-  #include "Platform.h"
 #else
   #error "Arduino version not supported. Please update your IDE."
 #endif

--- a/libraries/EasyVR/examples/EasyVRBridge/EasyVRBridge.ino
+++ b/libraries/EasyVR/examples/EasyVRBridge/EasyVRBridge.ino
@@ -19,7 +19,6 @@
 
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"
-  #include "Platform.h"
   #include "SoftwareSerial.h"
 #ifndef CDC_ENABLED
   // Shield Jumper on SW

--- a/libraries/EasyVR/examples/TestEasyVR/TestEasyVR.ino
+++ b/libraries/EasyVR/examples/TestEasyVR/TestEasyVR.ino
@@ -44,7 +44,6 @@
 
 #if defined(ARDUINO) && ARDUINO >= 100
   #include "Arduino.h"
-  #include "Platform.h"
   #include "SoftwareSerial.h"
 #ifndef CDC_ENABLED
   // Shield Jumper on SW


### PR DESCRIPTION
`Platform.h` is already included from Arduino.h.

Since Platform.h has been removed from Arduino core (starting from 1.6.0) the library didn't compile anymore. This commit solves the issue.
