### PR TITLE
Add library.json for PlatformIO integration

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,11 @@
+{
+	"name": "EasyVR",
+	"keywords": "speech, recognition, sensor, serial",
+	"description": "A library for the EasyVR line of products",
+	"repository":
+	{
+		"type": "git",
+		"url": "https://github.com/RoboTech-srl/EasyVR-Arduino.git"
+	},
+	"framework": "arduino"
+}


### PR DESCRIPTION
Platformio library registry http://platformio.org/#!/lib requires name,
keywords, description and repository fields at minimum:
http://docs.platformio.org/en/latest/librarymanager/creating.html#at-github

The corresponding values were taken from library.properties file.
